### PR TITLE
Add annotations future statement globally

### DIFF
--- a/mockafka/__init__.py
+++ b/mockafka/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .admin_client import FakeAdminClientImpl
 from .producer import FakeProducer
 from .conumser import FakeConsumer

--- a/mockafka/admin_client.py
+++ b/mockafka/admin_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from confluent_kafka.cimpl import NewTopic, NewPartitions
 
 from mockafka.cluster_metadata import ClusterMetadata

--- a/mockafka/aiokafka/__init__.py
+++ b/mockafka/aiokafka/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .aiokafka_admin_client import FakeAIOKafkaAdmin
 from .aiokafka_consumer import FakeAIOKafkaConsumer
 from .aiokafka_producer import FakeAIOKafkaProducer

--- a/mockafka/aiokafka/aiokafka_admin_client.py
+++ b/mockafka/aiokafka/aiokafka_admin_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict
 
 from aiokafka.admin import NewTopic, NewPartitions

--- a/mockafka/aiokafka/aiokafka_consumer.py
+++ b/mockafka/aiokafka/aiokafka_consumer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 from copy import deepcopy
 

--- a/mockafka/aiokafka/aiokafka_producer.py
+++ b/mockafka/aiokafka/aiokafka_producer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mockafka.kafka_store import KafkaStore
 from mockafka.message import Message
 

--- a/mockafka/broker_metadata.py
+++ b/mockafka/broker_metadata.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class BrokerMetadata(object):
     """
     Provides information about a Kafka broker.

--- a/mockafka/cluster_metadata.py
+++ b/mockafka/cluster_metadata.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mockafka.broker_metadata import BrokerMetadata
 from mockafka.kafka_store import KafkaStore
 from mockafka.topic_metadata import TopicMetadata

--- a/mockafka/conumser.py
+++ b/mockafka/conumser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 from copy import deepcopy
 

--- a/mockafka/decorators/__init__.py
+++ b/mockafka/decorators/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .aconsumer import aconsume
 from .aproducer import aproduce
 from .asetup_kafka import asetup_kafka

--- a/mockafka/decorators/aconsumer.py
+++ b/mockafka/decorators/aconsumer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import wraps
 
 from mockafka.aiokafka import FakeAIOKafkaConsumer

--- a/mockafka/decorators/aproducer.py
+++ b/mockafka/decorators/aproducer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import wraps
 
 from mockafka.aiokafka import FakeAIOKafkaProducer

--- a/mockafka/decorators/asetup_kafka.py
+++ b/mockafka/decorators/asetup_kafka.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import wraps
 
 from aiokafka.admin import NewTopic

--- a/mockafka/decorators/bulk_producer.py
+++ b/mockafka/decorators/bulk_producer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import wraps
 from mockafka import FakeProducer
 

--- a/mockafka/decorators/consumer.py
+++ b/mockafka/decorators/consumer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import wraps
 from mockafka import FakeConsumer
 

--- a/mockafka/decorators/producer.py
+++ b/mockafka/decorators/producer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import wraps
 from mockafka import FakeProducer
 

--- a/mockafka/decorators/setup_kafka.py
+++ b/mockafka/decorators/setup_kafka.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import wraps
 from mockafka.admin_client import FakeAdminClientImpl, NewTopic
 

--- a/mockafka/kafka_store.py
+++ b/mockafka/kafka_store.py
@@ -16,6 +16,8 @@ offset_store = {
 }
 """
 
+from __future__ import annotations
+
 from confluent_kafka import KafkaException
 from .message import Message
 from copy import deepcopy

--- a/mockafka/message.py
+++ b/mockafka/message.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from confluent_kafka import KafkaError

--- a/mockafka/producer.py
+++ b/mockafka/producer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mockafka.cluster_metadata import ClusterMetadata
 from mockafka.kafka_store import KafkaStore
 from mockafka.message import Message

--- a/mockafka/topic_metadata.py
+++ b/mockafka/topic_metadata.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class TopicMetadata(object):
     """
     Provides information about a Kafka topic.

--- a/tests/test_admin_client.py
+++ b/tests/test_admin_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import TestCase
 from mockafka.admin_client import FakeAdminClientImpl, NewPartitions, NewTopic
 from mockafka.kafka_store import KafkaStore

--- a/tests/test_aiokafka/test_aiokafka_consumer.py
+++ b/tests/test_aiokafka/test_aiokafka_consumer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import IsolatedAsyncioTestCase
 
 import pytest

--- a/tests/test_aiokafka/test_aiokafka_producer.py
+++ b/tests/test_aiokafka/test_aiokafka_producer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import IsolatedAsyncioTestCase
 
 import pytest

--- a/tests/test_aiokafka/test_async_decorators.py
+++ b/tests/test_aiokafka/test_async_decorators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from unittest import IsolatedAsyncioTestCase
 

--- a/tests/test_aiokafka/test_fake_aiokafka_admin_client.py
+++ b/tests/test_aiokafka/test_fake_aiokafka_admin_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import IsolatedAsyncioTestCase
 
 import pytest

--- a/tests/test_async_mockafka.py
+++ b/tests/test_async_mockafka.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from aiokafka.admin import NewTopic
 

--- a/tests/test_cluster_metadata.py
+++ b/tests/test_cluster_metadata.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mockafka.admin_client import FakeAdminClientImpl, NewTopic
 from mockafka.broker_metadata import BrokerMetadata
 from mockafka.cluster_metadata import ClusterMetadata

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import TestCase
 
 import pytest

--- a/tests/test_consumer_consistency.py
+++ b/tests/test_consumer_consistency.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import uuid
 from random import randint, choice
 from typing import Any

--- a/tests/test_docrators.py
+++ b/tests/test_docrators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mockafka import FakeConsumer, produce, bulk_produce, setup_kafka, Message
 from mockafka.admin_client import FakeAdminClientImpl, NewTopic
 from mockafka.producer import FakeProducer

--- a/tests/test_kafka_store.py
+++ b/tests/test_kafka_store.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import TestCase
 
 from parameterized import parameterized

--- a/tests/test_mockafka.py
+++ b/tests/test_mockafka.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mockafka import FakeProducer, FakeConsumer, FakeAdminClientImpl
 from mockafka.admin_client import NewTopic
 from random import randint

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import TestCase
 
 import pytest


### PR DESCRIPTION
Add annotations future statement globally.

Enables PEP 585 type annotations in Python 3.8. The test suite succeeds under Python 3.8 following this change.

Fixes #82.