### PR TITLE
Feature/add stop in aioproducer

### DIFF
--- a/docs/async-fake-aiokafka-produce.md
+++ b/docs/async-fake-aiokafka-produce.md
@@ -27,6 +27,9 @@ The `FakeAIOKafkaProducer` class is a mock implementation of aiokafka's AIOKafka
 #### `start(self)`
 - **Description:** No-operation.
 
+#### `stop(self)`
+- **Description:** No-operation.
+
 #### `send(self, *args, **kwargs)`
 - **Description:** Calls `_produce()` with keyword arguments.
 - **Parameters:**
@@ -48,4 +51,4 @@ fake_producer = FakeAIOKafkaProducer()
 
 # Produce a message
 await fake_producer.send(topic='sample_topic', value='Hello, Kafka!', partition=0)
-``` 
+```

--- a/mockafka/aiokafka/aiokafka_producer.py
+++ b/mockafka/aiokafka/aiokafka_producer.py
@@ -18,6 +18,7 @@ class FakeAIOKafkaProducer:
     - _produce(): Create a Message and produce to KafkaStore.
       Takes topic, value, and optional partition.
     - start(): No-op.
+    - stop(): No-op.
     - send(): Call _produce() with kwargs.
     - send_and_wait(): Call send().
     """
@@ -31,6 +32,9 @@ class FakeAIOKafkaProducer:
         self.kafka.produce(message=message, topic=topic, partition=kwargs["partition"])
 
     async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
         pass
 
     async def send(

--- a/tests/test_aiokafka/test_aiokafka_producer.py
+++ b/tests/test_aiokafka/test_aiokafka_producer.py
@@ -88,7 +88,13 @@ class TestFakeProducer(IsolatedAsyncioTestCase):
 
     async def test_send_and_wait(self):
         await self._create_mock_topic()
-        await self.producer.send_and_wait("topic_test", "sdfjhasdfhjsa", key="datakey")
+
+        await self.producer.start()
+        try:
+            await self.producer.send_and_wait("topic_test", "sdfjhasdfhjsa", key="datakey")
+        finally:
+            await self.producer.stop()
+
         message: Message = self.kafka.get_messages_in_partition(
             topic="topic_test", partition=0
         )[0]


### PR DESCRIPTION
#85 
I add a `stop` function for `FakeAIOKafkaProducer`, and modified `test_send_and_wait` to fit [here's](https://aiokafka.readthedocs.io/en/stable/#aiokafkaproducer) sample code.