### PR TITLE
Fix implementation of repeated single-message fetching

### DIFF
--- a/mockafka/aiokafka/aiokafka_consumer.py
+++ b/mockafka/aiokafka/aiokafka_consumer.py
@@ -95,24 +95,23 @@ class FakeAIOKafkaConsumer:
                 next_offset = self.kafka.get_partition_next_offset(
                     topic=topic, partition=partition
                 )
-                consumer_amount = self.consumer_store.get(
-                    self._get_key(topic, partition)
-                )
                 if first_offset == next_offset:
+                    # Topic partition is empty
                     continue
 
+                topic_key = self._get_key(topic, partition)
+
+                consumer_amount = self.consumer_store.setdefault(
+                    topic_key, first_offset
+                )
                 if consumer_amount == next_offset:
+                    # Topic partition is exhausted
                     continue
 
-                if consumer_amount is not None:
-                    self.consumer_store[self._get_key(topic, partition)] += 1
-                else:
-                    self.consumer_store[self._get_key(topic, partition)] = (
-                        first_offset + 1
-                    )
+                self.consumer_store[topic_key] += 1
 
                 return self.kafka.get_message(
-                    topic=topic, partition=partition, offset=first_offset
+                    topic=topic, partition=partition, offset=consumer_amount
                 )
 
         return None

--- a/mockafka/conumser.py
+++ b/mockafka/conumser.py
@@ -159,24 +159,23 @@ class FakeConsumer(object):
                 next_offset = self.kafka.get_partition_next_offset(
                     topic=topic, partition=partition
                 )
-                consumer_amount = self.consumer_store.get(
-                    self._get_key(topic, partition)
-                )
                 if first_offset == next_offset:
+                    # Topic is empty
                     continue
 
+                topic_key = self._get_key(topic, partition)
+
+                consumer_amount = self.consumer_store.setdefault(
+                    topic_key, first_offset
+                )
                 if consumer_amount == next_offset:
+                    # Topic is exhausted
                     continue
 
-                if consumer_amount is not None:
-                    self.consumer_store[self._get_key(topic, partition)] += 1
-                else:
-                    self.consumer_store[self._get_key(topic, partition)] = (
-                        first_offset + 1
-                    )
+                self.consumer_store[topic_key] += 1
 
                 return self.kafka.get_message(
-                    topic=topic, partition=partition, offset=first_offset
+                    topic=topic, partition=partition, offset=consumer_amount
                 )
 
         return None

--- a/tests/test_aiokafka/test_aiokafka_consumer.py
+++ b/tests/test_aiokafka/test_aiokafka_consumer.py
@@ -61,7 +61,7 @@ class TestAIOKAFKAFakeConsumer(IsolatedAsyncioTestCase):
         message = await self.consumer.getone()
         self.assertEqual(message.value(payload=None), "test")
         message = await self.consumer.getone()
-        self.assertEqual(message.value(payload=None), "test")
+        self.assertEqual(message.value(payload=None), "test1")
 
         self.assertIsNone(await self.consumer.getone())
         self.assertIsNone(await self.consumer.getone())

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -76,7 +76,7 @@ class TestFakeConsumer(TestCase):
         message = self.consumer.poll()
         self.assertEqual(message.value(payload=None), "test")
         message = self.consumer.poll()
-        self.assertEqual(message.value(payload=None), "test")
+        self.assertEqual(message.value(payload=None), "test1")
 
         self.assertIsNone(self.consumer.poll())
         self.assertIsNone(self.consumer.poll())


### PR DESCRIPTION
## Summary

This brings the mock implementations in line with the behaviour observed in the default configurations of `confluent-kafka` and `aiokafka` respectively, both of which return subsequent messages on subsequent calls.

## Testing

Tested by running kafka locally and validating the behaviour of the relevant libraries manually. Commands & demo scripts below.

```
$ docker run --detach -p 9092:9092 --rm apache/kafka
$ docker run -it --network=host --rm apache/kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --create --topic testing-topic
$ docker run -it --network=host --rm apache/kafka /opt/kafka/bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic testing-topic
```

``` python
import uuid
import confluent_kafka

def main():
    consumer = confluent_kafka.Consumer({
        'bootstrap.servers': 'localhost:9092',
        'group.id': f'testing-group-{uuid.uuid4()}',
    })
    consumer.subscribe(['testing-topic'])
    print("Running")
    while True:
        msg = consumer.poll()
        print((msg.topic(), msg.key(), msg.value()))

main()
```
``` python
import asyncio
import aiokafka

async def main():
    consumer = aiokafka.AIOKafkaConsumer('testing-topic')
    await consumer.start()
    print("Running")
    while True:
        print(await consumer.getone())

asyncio.run(main())
```
