### PR TITLE
Flesh out FakeAIOKafkaConsumer

### DIFF
--- a/mockafka/aiokafka/aiokafka_consumer.py
+++ b/mockafka/aiokafka/aiokafka_consumer.py
@@ -44,18 +44,16 @@ class FakeAIOKafkaConsumer:
       Updates consumer_store as messages are consumed.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *topics: str, **kwargs: Any) -> None:
         self.kafka = KafkaStore()
         self.consumer_store: dict[str, int] = {}
-        self.subscribed_topic: list = []
+        self.subscribed_topic = [x for x in topics if self.kafka.is_topic_exist(x)]
 
     async def start(self) -> None:
         self.consumer_store = {}
-        self.subscribed_topic = []
 
     async def stop(self) -> None:
         self.consumer_store = {}
-        self.subscribed_topic = []
 
     async def commit(self):
         for item in self.consumer_store:

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 addopts = --ignore=docs --cov-config=.coveragerc --cov=mockafka -vv
 pythonpath = .
 python_files = tests.py test_*.py *_tests.py
+
+filterwarnings =
+    ignore:`pattern` only support topics which exist at the time of subscription.:UserWarning

--- a/tests/test_aiokafka/test_aiokafka_consumer.py
+++ b/tests/test_aiokafka/test_aiokafka_consumer.py
@@ -91,6 +91,17 @@ class TestAIOKAFKAFakeConsumer(IsolatedAsyncioTestCase):
 
         self.assertEqual(self.consumer.subscribed_topic, topics)
 
+    async def test_subscribe_pattern(self):
+        test_topic_2 = "test_topic_2"
+        self.kafka.create_partition(topic=self.test_topic, partitions=10)
+        self.kafka.create_partition(topic=test_topic_2, partitions=10)
+        self.kafka.create_partition(topic="other_topic", partitions=10)
+
+        self.consumer.subscribe(pattern=r"^test_.*")
+
+        topics = [self.test_topic, test_topic_2]
+        self.assertEqual(self.consumer.subscribed_topic, topics)
+
     async def test_subscribe_topic_not_exist(self):
         topics = [self.test_topic]
         self.consumer.subscribe(topics=topics)

--- a/tests/test_aiokafka/test_aiokafka_consumer.py
+++ b/tests/test_aiokafka/test_aiokafka_consumer.py
@@ -253,8 +253,11 @@ class TestAIOKAFKAFakeConsumer(IsolatedAsyncioTestCase):
         self.assertEqual(self.consumer.subscribed_topic, topics)
 
     async def test_subscribe_topic_not_exist(self):
-        topics = [self.test_topic]
+        self.create_topic()
+        topics = [self.test_topic, "missing-topic"]
         self.consumer.subscribe(topics=topics)
+
+        self.assertEqual(self.consumer.subscribed_topic, [self.test_topic])
 
     async def test_lifecycle(self):
         test_topic_2 = "test_topic_2"


### PR DESCRIPTION
This adds missing parameters to:
- `FakeAIOKafkaConsumer.subscribe`
- `FakeAIOKafkaConsumer.getone`
- `FakeAIOKafkaConsumer.getmany`, which it also implements

Mostly via inspection of `aiokafka`, though also some manual testing. I've also validated this by using it in some integration tests for a codebase already in production.

Fixes #107.

Builds on #110 and #111, which it contains; suggest reviewing them first then only considering the other changes here.

Review by commit may be useful here to understand the flow of some of the refactors.