### PR TITLE
Enforce type validity and publish types in the package

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Typecheck with mypy
         run: |
-          poetry run mypy mockafka tests || true
+          poetry run mypy mockafka tests
 
       - name: Test with pytest
         run: |

--- a/mockafka/aiokafka/aiokafka_consumer.py
+++ b/mockafka/aiokafka/aiokafka_consumer.py
@@ -44,18 +44,16 @@ class FakeAIOKafkaConsumer:
       Updates consumer_store as messages are consumed.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *topics: str, **kwargs: Any) -> None:
         self.kafka = KafkaStore()
         self.consumer_store: dict[str, int] = {}
-        self.subscribed_topic: list = []
+        self.subscribed_topic = [x for x in topics if self.kafka.is_topic_exist(x)]
 
     async def start(self) -> None:
         self.consumer_store = {}
-        self.subscribed_topic = []
 
     async def stop(self) -> None:
         self.consumer_store = {}
-        self.subscribed_topic = []
 
     async def commit(self):
         for item in self.consumer_store:

--- a/mockafka/conumser.py
+++ b/mockafka/conumser.py
@@ -51,7 +51,7 @@ class FakeConsumer(object):
         """
         self.kafka = KafkaStore()
         self.consumer_store: dict[str, int] = {}
-        self.subscribed_topic: list = []
+        self.subscribed_topic: list[str] = []
 
     def consume(self, num_messages=1, *args, **kwargs) -> list[Message]:
         """

--- a/mockafka/message.py
+++ b/mockafka/message.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import Optional, Any
 
 from confluent_kafka import KafkaError  # type: ignore[import-untyped]
@@ -16,7 +17,7 @@ class Message:
         self._latency: Optional[float] = kwargs.get("latency", None)
         self._leader_epoch: Optional[int] = kwargs.get("leader_epoch", None)
         self._partition: Optional[int] = kwargs.get("partition", None)
-        self._timestamp: int = kwargs.get("timestamp", None)
+        self._timestamp: int = kwargs.get("timestamp") or int(time.time() * 1000)
 
     def offset(self, *args, **kwargs):
         return self._offset

--- a/mockafka/topic_metadata.py
+++ b/mockafka/topic_metadata.py
@@ -12,7 +12,7 @@ class TopicMetadata(object):
     # Sphinx issue where it tries to reference the same instance variable
     # on other classes which raises a warning/error.
 
-    def __init__(self, topic_name: str, partition_num: list = []):
+    def __init__(self, topic_name: str, partition_num: list[int] = []):
         self.topic = topic_name
         """Topic name"""
         self.partitions = partition_num

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ documentation = "https://mockafka-py.readthedocs.io/"
 description = "A mock library for confluent kafka"
 readme = "README.md"
 packages = [{ include = "mockafka" }]
+classifiers = [
+    "Typing :: Typed",
+]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,12 @@ mkdocstrings = { extras = ["python"], version = ">=0.23,<0.25" }
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.mypy]
+warn_unused_ignores = true
+
+no_implicit_optional = true
+
+disallow_subclassing_any = true
+
+enable_error_code = "ignore-without-code"

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 addopts = --ignore=docs --cov-config=.coveragerc --cov=mockafka -vv
 pythonpath = .
 python_files = tests.py test_*.py *_tests.py
+
+filterwarnings =
+    ignore:`pattern` only support topics which exist at the time of subscription.:UserWarning

--- a/tests/test_aiokafka/test_aiokafka_consumer.py
+++ b/tests/test_aiokafka/test_aiokafka_consumer.py
@@ -91,6 +91,17 @@ class TestAIOKAFKAFakeConsumer(IsolatedAsyncioTestCase):
 
         self.assertEqual(self.consumer.subscribed_topic, topics)
 
+    async def test_subscribe_pattern(self):
+        test_topic_2 = "test_topic_2"
+        self.kafka.create_partition(topic=self.test_topic, partitions=10)
+        self.kafka.create_partition(topic=test_topic_2, partitions=10)
+        self.kafka.create_partition(topic="other_topic", partitions=10)
+
+        self.consumer.subscribe(pattern=r"^test_.*")
+
+        topics = [self.test_topic, test_topic_2]
+        self.assertEqual(self.consumer.subscribed_topic, topics)
+
     async def test_subscribe_topic_not_exist(self):
         topics = [self.test_topic]
         self.consumer.subscribe(topics=topics)

--- a/tests/test_aiokafka/test_aiokafka_consumer.py
+++ b/tests/test_aiokafka/test_aiokafka_consumer.py
@@ -253,8 +253,11 @@ class TestAIOKAFKAFakeConsumer(IsolatedAsyncioTestCase):
         self.assertEqual(self.consumer.subscribed_topic, topics)
 
     async def test_subscribe_topic_not_exist(self):
-        topics = [self.test_topic]
+        self.create_topic()
+        topics = [self.test_topic, "missing-topic"]
         self.consumer.subscribe(topics=topics)
+
+        self.assertEqual(self.consumer.subscribed_topic, [self.test_topic])
 
     async def test_lifecycle(self):
         test_topic_2 = "test_topic_2"

--- a/tests/test_aiokafka/test_async_decorators.py
+++ b/tests/test_aiokafka/test_async_decorators.py
@@ -50,8 +50,8 @@ class TestDecorators(IsolatedAsyncioTestCase):
         self.consumer.subscribe(topics=["test"])
         message = await self.consumer.getone()
 
-        self.assertEqual(message.value(payload=None), "test_value")
-        self.assertEqual(message.key(), "test_key")
+        self.assertEqual(message.value, b"test_value")
+        self.assertEqual(message.key, b"test_key")
 
         # commit message and check
         await self.consumer.commit()
@@ -67,7 +67,7 @@ class TestDecorators(IsolatedAsyncioTestCase):
 
         # Order unknown as partition order is not predictable
         messages = [
-            (x.key(), x.value(payload=None))
+            (x.key, x.value)
             for x in (
                 await self.consumer.getone(),
                 await self.consumer.getone(),
@@ -75,8 +75,8 @@ class TestDecorators(IsolatedAsyncioTestCase):
         ]
         self.assertCountEqual(
             [
-                ("test_key", "test_value"),
-                ("test_key1", "test_value1"),
+                (b"test_key", b"test_value"),
+                (b"test_key1", b"test_value1"),
             ],
             messages,
         )
@@ -94,8 +94,8 @@ class TestDecorators(IsolatedAsyncioTestCase):
         self.consumer.subscribe(topics=["test_topic"])
 
         message = await self.consumer.getone()
-        self.assertEqual(message.value(payload=None), "test_value1")
-        self.assertEqual(message.key(), "test_")
+        self.assertEqual(message.value, b"test_value1")
+        self.assertEqual(message.key, b"test_")
 
     @asetup_kafka(topics=[{"topic": "test_topic", "partition": 16}])
     @aproduce(topic="test_topic", partition=5, key="test_", value="test_value1")
@@ -105,5 +105,5 @@ class TestDecorators(IsolatedAsyncioTestCase):
         if message is None:
             return
 
-        self.assertEqual(message.key(), "test_")
-        self.assertEqual(message._partition, 5)
+        self.assertEqual(message.key, b"test_")
+        self.assertEqual(message.partition, 5)

--- a/tests/test_async_mockafka.py
+++ b/tests/test_async_mockafka.py
@@ -50,8 +50,8 @@ async def test_produce_and_consume():
     consumer.subscribe(["test_topic"])
     message = await consumer.getone()
 
-    assert message.key() == "test_key"
-    assert message.value() == "test_value"
+    assert message.key == b"test_key"
+    assert message.value == b"test_value"
 
     message = await consumer.getone()
 
@@ -67,8 +67,8 @@ async def test_produce_with_decorator():
     consumer.subscribe(["test_topic"])
     message = await consumer.getone()
 
-    assert message.key() == "test_key"
-    assert message.value() == "test_value"
+    assert message.key == b"test_key"
+    assert message.value == b"test_value"
 
 
 @pytest.mark.asyncio
@@ -79,5 +79,5 @@ async def test_produce_and_consume_with_decorator(message=None):
     if not message:
         return
 
-    assert message.key() == "test_key"
-    assert message.value() == "test_value"
+    assert message.key == b"test_key"
+    assert message.value == b"test_value"


### PR DESCRIPTION
Builds on #115 (and #112); suggest reviewing those first.

This adds a mypy config which avoids some pitfalls but which the codebase already passes, then enforces mypy in CI and publishes the types in the package.