### PR TITLE
Have FakeAIOKafkaConsumer.topics better match the real behaviour

### DIFF
--- a/mockafka/aiokafka/aiokafka_consumer.py
+++ b/mockafka/aiokafka/aiokafka_consumer.py
@@ -112,7 +112,7 @@ class FakeAIOKafkaConsumer:
         self.consumer_store = {}
 
     async def topics(self) -> set[str]:
-        return set(self.subscribed_topic)
+        return set(self.kafka.topic_list())
 
     def subscribe(
             self,


### PR DESCRIPTION
AIOKafkaConsumer.topics returns all the topics which the user can see within the connected Kafka instance. Since our mock doesn't handle any form of authentication/ACLs, just return all known topics.