### PR TITLE
Implement dynamic timestamp types in Message class

### DIFF
--- a/mockafka/aiokafka/aiokafka_consumer.py
+++ b/mockafka/aiokafka/aiokafka_consumer.py
@@ -102,8 +102,8 @@ class FakeAIOKafkaConsumer:
         for item in self.consumer_store:
             topic, partition = item.split("*")
             if (
-                self.kafka.get_partition_first_offset(topic, partition)
-                <= self.consumer_store[item]
+                    self.kafka.get_partition_first_offset(topic, partition)
+                    <= self.consumer_store[item]
             ):
                 self.kafka.set_first_offset(
                     topic=topic, partition=partition, value=self.consumer_store[item]
@@ -115,11 +115,12 @@ class FakeAIOKafkaConsumer:
         return set(self.kafka.topic_list())
 
     def subscribe(
-        self,
-        topics: list[str] | set[str] | tuple[str, ...] = (),
-        pattern: str | None = None,
-        listener: Optional[ConsumerRebalanceListener] = None,
+            self,
+            topics: list[str] | set[str] | tuple[str, ...] = (),
+            pattern: str | None = None,
+            listener: Optional[ConsumerRebalanceListener] = None,
     ) -> None:
+
         if topics and pattern:
             raise ValueError(
                 "Only one of `topics` and `pattern` may be provided (not both).",
@@ -162,9 +163,8 @@ class FakeAIOKafkaConsumer:
     def _get_key(self, topic, partition) -> str:
         return f"{topic}*{partition}"
 
-    def _fetch_one(
-        self, topic: str, partition: int
-    ) -> Optional[ConsumerRecord[bytes, bytes]]:
+    def _fetch_one(self, topic: str, partition: int) -> Optional[ConsumerRecord[bytes, bytes]]:
+
         first_offset = self.kafka.get_partition_first_offset(
             topic=topic, partition=partition
         )
@@ -190,9 +190,10 @@ class FakeAIOKafkaConsumer:
         return message_to_record(message, offset=consumer_amount)
 
     def _fetch(
-        self,
-        partitions: Iterable[TopicPartition],
+            self,
+            partitions: Iterable[TopicPartition],
     ) -> Iterator[tuple[TopicPartition, ConsumerRecord[bytes, bytes]]]:
+
         if partitions:
             partitions_to_consume = list(partitions)
         else:
@@ -214,7 +215,7 @@ class FakeAIOKafkaConsumer:
                 yield tp, record
 
     async def getone(
-        self, *partitions: TopicPartition
+            self, *partitions: TopicPartition
     ) -> Optional[ConsumerRecord[bytes, bytes]]:
         if self._is_closed:
             raise ConsumerStoppedError()
@@ -225,10 +226,10 @@ class FakeAIOKafkaConsumer:
         return None
 
     async def getmany(
-        self,
-        *partitions: TopicPartition,
-        timeout_ms: int = 0,
-        max_records: Optional[int] = None,
+            self,
+            *partitions: TopicPartition,
+            timeout_ms: int = 0,
+            max_records: Optional[int] = None,
     ) -> dict[TopicPartition, list[ConsumerRecord[bytes, bytes]]]:
         if self._is_closed:
             raise ConsumerStoppedError()

--- a/mockafka/message.py
+++ b/mockafka/message.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import time
-from typing import Optional, Any
+from typing import Any, Optional
 
-from confluent_kafka import KafkaError  # type: ignore[import-untyped]
+from confluent_kafka import (  # type: ignore[import-untyped]
+    TIMESTAMP_CREATE_TIME,
+    TIMESTAMP_LOG_APPEND_TIME,
+    TIMESTAMP_NOT_AVAILABLE,
+    KafkaError,
+)
 
 
 class Message:
@@ -18,6 +23,10 @@ class Message:
         self._leader_epoch: Optional[int] = kwargs.get("leader_epoch", None)
         self._partition: Optional[int] = kwargs.get("partition", None)
         self._timestamp: int = kwargs.get("timestamp") or int(time.time() * 1000)
+        self._timestamp_type = kwargs.get("timestamp_type", TIMESTAMP_CREATE_TIME)
+        self._broker_receive_time = kwargs.get("broker_receive_time") or int(
+            time.time() * 1000
+        )
 
     def offset(self, *args, **kwargs):
         return self._offset
@@ -37,8 +46,15 @@ class Message:
     def value(self, *args, **kwargs):
         return self._value
 
-    def timestamp(self, *args, **kwargs):
-        return self._timestamp
+    def timestamp(self, *args, **kwargs) -> tuple[int, int]:
+        ts_info: tuple[int, int]
+        if self._timestamp_type == TIMESTAMP_NOT_AVAILABLE:
+            ts_info = (TIMESTAMP_NOT_AVAILABLE, 0)
+        elif self._timestamp_type == TIMESTAMP_LOG_APPEND_TIME:
+            ts_info = (TIMESTAMP_LOG_APPEND_TIME, self._broker_receive_time)
+        else:
+            ts_info = (self._timestamp_type, self._timestamp)
+        return ts_info
 
     def topic(self, *args, **kwargs):
         return self._topic
@@ -46,7 +62,7 @@ class Message:
     def partition(self, *args, **kwargs):
         return self._partition
 
-    def error(self):
+    def error(self) -> Any | None:
         return self._error
 
     def set_headers(self, *args, **kwargs):  # real signature unknown

--- a/mockafka/message.py
+++ b/mockafka/message.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Optional
+from typing import Optional, Any
 
 from confluent_kafka import (  # type: ignore[import-untyped]
     TIMESTAMP_CREATE_TIME,
@@ -62,7 +62,7 @@ class Message:
     def partition(self, *args, **kwargs):
         return self._partition
 
-    def error(self) -> Any | None:
+    def error(self):
         return self._error
 
     def set_headers(self, *args, **kwargs):  # real signature unknown

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -175,3 +175,22 @@ class TestFakeConsumer(TestCase):
     def test_incremental_unassign(self):
         # This method Does not support in mockafka
         self.consumer.incremental_unassign(partitions=None)
+
+    def test_message_timestamp_format(self):
+        self.create_topic()
+        self.produce_message()
+        self.consumer.subscribe(topics=[self.test_topic])
+        message = self.consumer.poll()
+
+        # Fetch the timestamp from the message
+        timestamp_type, timestamp = message.timestamp()
+
+        # Expected timestamp types (matching confluent_kafka Message class)
+        timestamp_create_time = 0
+        timestamp_log_append_time = 1
+        timestamp_not_available = 2
+
+        # Test that the timestamp is returned as a tuple[int, int]
+        self.assertIsInstance(timestamp, int)
+        self.assertIsInstance(timestamp_type, int)
+        self.assertIn(timestamp_type, [timestamp_create_time, timestamp_log_append_time, timestamp_not_available])


### PR DESCRIPTION
Aligning with confluent-kafka behavior,
Implemented broker receive time simulation for
Updated timestamp() method to return a tuple[int, int] as per confluent-kafka specs.