### PR TITLE
:bug: Fix #149 - Ensure Compatibility with aiokafka ConsumerRecord Headers

### DIFF
--- a/mockafka/aiokafka/aiokafka_consumer.py
+++ b/mockafka/aiokafka/aiokafka_consumer.py
@@ -36,8 +36,15 @@ def message_to_record(message: Message, offset: int) -> ConsumerRecord[bytes, by
     key_str: Optional[str] = message.key()
     value_str: Optional[str] = message.value()
 
-    key = key_str.encode() if key_str is not None else None
-    value = value_str.encode() if value_str is not None else None
+    if not isinstance(key_str, bytes):
+        key = key_str.encode() if key_str is not None else None
+    else:
+        key = key_str
+
+    if not isinstance(value_str, bytes):
+        value = value_str.encode() if value_str is not None else None
+    else:
+        value = value_str
 
     return ConsumerRecord(
         topic=topic,

--- a/mockafka/aiokafka/aiokafka_producer.py
+++ b/mockafka/aiokafka/aiokafka_producer.py
@@ -32,13 +32,13 @@ class FakeAIOKafkaProducer:
         self.kafka = KafkaStore()
 
     def _translate_header_to_internal_format(self, headers: Sequence[Tuple[str, bytes]]) -> dict:
-        _header_dict: dict = defaultdict(dict)
+        header_dict: dict[str, bytes] = defaultdict(bytes)
         if not headers:
-            return _header_dict
+            return header_dict
 
         for item in headers:
-            _header_dict[item[0]] = item[1]
-        return _header_dict
+            header_dict[item[0]] = item[1]
+        return header_dict
 
     async def _produce(self, topic, value=None, *args, **kwargs) -> None:
         # create a message and call produce kafka

--- a/tests/test_async_mockafka.py
+++ b/tests/test_async_mockafka.py
@@ -37,7 +37,7 @@ async def test_produce_and_consume():
     producer = FakeAIOKafkaProducer()
     await producer.start()
     await producer.send(
-        headers={},
+        headers=[],
         key="test_key",
         value="test_value",
         topic="test_topic",
@@ -81,3 +81,22 @@ async def test_produce_and_consume_with_decorator(message=None):
 
     assert message.key == b"test_key"
     assert message.value == b"test_value"
+
+
+@pytest.mark.asyncio
+@asetup_kafka(topics=[{"topic": "test_topic1", "partition": 2}], clean=True)
+async def test_produce_and_consume_with_headers():
+    producer = FakeAIOKafkaProducer()
+    consumer = FakeAIOKafkaConsumer()
+    await producer.start()
+    await consumer.start()
+    consumer.subscribe({"test_topic1"})
+    await producer.send(
+        topic="test_topic1",
+        headers=[('header_name', b"test"), ('header_name2', b"test")],
+        key=b"test"
+    )
+    await producer.stop()
+    record = await consumer.getone()
+    assert record.headers == (('header_name', b"test"), ('header_name2', b"test"))
+    await consumer.stop()


### PR DESCRIPTION
This PR addresses issue #149 by enhancing the header handling logic to ensure compatibility with aiokafka's **ConsumerRecord**. 
Specifically, the headers are now processed as a 'Sequence[Tuple[str, bytes]]', which aligns with aiokafka's expected format. This change prevents potential errors when dealing with Kafka message headers in the application.