### PR TITLE
Remove extra random.shuffle in consumer

### DIFF
--- a/mockafka/conumser.py
+++ b/mockafka/conumser.py
@@ -152,7 +152,6 @@ class FakeConsumer(object):
         random.shuffle(topics_to_consume)
         for topic in topics_to_consume:
             partition_to_consume = deepcopy(self.kafka.partition_list(topic=topic))
-            random.shuffle(topics_to_consume)
             for partition in partition_to_consume:
                 first_offset = self.kafka.get_partition_first_offset(
                     topic=topic, partition=partition


### PR DESCRIPTION
Removed an extra random.shuffle to fix a bug where if you are subscribe to more than 1 topic, and produce to just 1 topic, at some point you will receive None for a message because it checks the same topic twice for a new message.  Also added a test around the issue.