### PR TITLE
Add PartitionMetadata to TopicMetadata Response

### DIFF
--- a/mockafka/partition_metadata.py
+++ b/mockafka/partition_metadata.py
@@ -28,7 +28,7 @@ class PartitionMetadata(object):
         """Partition error, or None. Value is a KafkaError object."""
         
         # If default args were provided then initialize the Partition with a single replica
-        if leader == -1 and replicas is None  and isrs is None:
+        if leader == -1 and replicas is None and isrs is None:
             self.leader = 1
             self.replicas = [1]
             self.isrs = [1]

--- a/mockafka/partition_metadata.py
+++ b/mockafka/partition_metadata.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from confluent_kafka import (  # type: ignore[import-untyped]
+    KafkaError,
+)
+
+class PartitionMetadata(object):
+    """
+    Provides information about a Kafka partition.
+
+    This class is typically not user instantiated.
+    """
+
+    # The dash in "-topic" and "-error" is needed to circumvent a
+    # Sphinx issue where it tries to reference the same instance variable
+    # on other classes which raises a warning/error.
+
+    def __init__(self, id: int, leader: int = -1, replicas: list[int] | None = None, isrs: list[int] | None = None, error: KafkaError | None = None):
+        self.id = id
+        """Partition Id"""
+        self.leader = leader
+        """Current leader broker for this partition, or -1."""
+        self.replicas = replicas or []
+        """List of replica broker ids for this partition."""
+        self.isrs = isrs or []
+        """List of in-sync-replica broker ids for this partition."""
+        self.error = error
+        """Partition error, or None. Value is a KafkaError object."""
+        
+        # If default args were provided then initialize the Partition with a single replica
+        if leader == -1 and replicas is None  and isrs is None:
+            self.leader = 1
+            self.replicas = [1]
+            self.isrs = [1]
+            
+    def __str__(self):
+        return self.id
+
+    def __len__(self):
+        return len(self.replicas)

--- a/mockafka/topic_metadata.py
+++ b/mockafka/topic_metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from mockafka.partition_metadata import PartitionMetadata
 
 class TopicMetadata(object):
     """
@@ -15,7 +16,7 @@ class TopicMetadata(object):
     def __init__(self, topic_name: str, partition_num: list[int] = []):
         self.topic = topic_name
         """Topic name"""
-        self.partitions = partition_num
+        self.partitions = {num: PartitionMetadata(id=num) for num in partition_num}
         """Map of partitions indexed by partition id. Value is a PartitionMetadata object."""
         self.error = None
         """Topic error, or None. Value is a KafkaError object."""

--- a/tests/test_admin_client.py
+++ b/tests/test_admin_client.py
@@ -62,6 +62,19 @@ class TestFakeAdminClient(TestCase):
         self.assertEqual(len(cluster_metadata.topics["test1"]), 1)
         self.assertEqual(len(cluster_metadata.topics["test2"]), 4)
         self.assertEqual(len(cluster_metadata.topics["test3"]), 16)
+    
+    def test_list_partitions(self):
+        self.admin.create_topics(
+            topics=[
+                NewTopic(topic="test4", num_partitions=4),
+            ]
+        )
+
+        cluster_metadata = self.admin.list_topics()
+        topic_metadata = cluster_metadata.topics["test4"]
+        self.assertEqual(len(topic_metadata.partitions), 4)
+        self.assertEqual(topic_metadata.partitions[0].id, 0)
+        self.assertEqual(len(topic_metadata.partitions[0].replicas), 1)
 
     def test_describe_acls(self):
         # This method Does not support in mockafka


### PR DESCRIPTION
Hey @alm0ra,

I just wanted to say thank you for creating this awesome package! I found a few minor discrepancies between your library and `confluent_kafka` so I'll be opening up a couple of issues/PRs in the coming days. Please let me know if there's anything I should be doing differently. 


---

This PR fixes a minor issue in the return type of `TopicMetadata.partitions`. The current library returns a list of ints when it should actually be a mapping of ints to PartitionMetadata objects. This doesn't impact iterating the list but it does impact accessing partition/replica info.

This PR resolves this by adding a new PartitionMetadata class to mirror the confluent_kafka one.

Closes https://github.com/alm0ra/mockafka-py/issues/182