### PR TITLE
Fix consume decorator signature

### DIFF
--- a/mockafka/decorators/aconsumer.py
+++ b/mockafka/decorators/aconsumer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import wraps
+from inspect import signature
 
 from mockafka.aiokafka import FakeAIOKafkaConsumer
 
@@ -51,6 +52,12 @@ def aconsume(topics: list[str], auto_commit: bool = True):
             # Call the original function without a message parameter
             result = await func(*args, **kwargs)
             return result
+
+        # Avoid exposing the original ``message`` parameter to pytest's
+        # introspection by removing it from the wrapper's signature.
+        sig = signature(func)
+        parameters = [p for p in sig.parameters.values() if p.name != "message"]
+        wrapper.__signature__ = sig.replace(parameters=parameters)
 
         return wrapper
 

--- a/mockafka/decorators/consumer.py
+++ b/mockafka/decorators/consumer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import wraps
+from inspect import signature
 from mockafka import FakeConsumer
 
 
@@ -41,6 +42,12 @@ def consume(topics: list[str], auto_commit: bool = True):
             # Call the original function without a message parameter
             result = func(*args, **kwargs)
             return result
+
+        # Remove `message` from the wrapper's signature so pytest does not
+        # expect a fixture with that name when collecting the test.
+        sig = signature(func)
+        parameters = [p for p in sig.parameters.values() if p.name != "message"]
+        wrapper.__signature__ = sig.replace(parameters=parameters)
 
         return wrapper
 

--- a/tests/test_pytest_decorators.py
+++ b/tests/test_pytest_decorators.py
@@ -1,0 +1,11 @@
+import pytest
+from mockafka import produce, consume, FakeConsumer
+
+
+@produce(topic='test_topic', key='k', value='v', partition=0)
+@consume(topics=['test_topic'])
+def test_produce_and_consume_decorator(message):
+    """Ensure @produce and @consume work together under pytest."""
+    assert message.key() == 'k'
+    assert message.value(payload=None) == 'v'
+


### PR DESCRIPTION
## Summary
- fix `consume` and `aconsume` decorators so pytest doesn't look for a nonexistent `message` fixture
- add regression test showing README example works under pytest

## Testing
- `python3 -m pytest tests/test_pytest_decorators.py -q` *(fails: No module named pytest)*