### PR TITLE
Add async context manager support for producers & consumers

### DIFF
--- a/mockafka/aiokafka/aiokafka_consumer.py
+++ b/mockafka/aiokafka/aiokafka_consumer.py
@@ -14,6 +14,7 @@ from aiokafka.structs import (  # type: ignore[import-untyped]
     ConsumerRecord,
     TopicPartition,
 )
+from typing_extensions import Self
 
 from mockafka.kafka_store import KafkaStore
 from mockafka.message import Message
@@ -243,3 +244,15 @@ class FakeAIOKafkaConsumer:
             result[tp].append(record)
 
         return dict(result)
+
+    async def __aenter__(self) -> Self:
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exception_type: object,
+        exception: object,
+        traceback: object,
+    ) -> None:
+        await self.stop()

--- a/mockafka/aiokafka/aiokafka_producer.py
+++ b/mockafka/aiokafka/aiokafka_producer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing_extensions import Self
+
 from mockafka.kafka_store import KafkaStore
 from mockafka.message import Message
 
@@ -74,3 +76,15 @@ class FakeAIOKafkaProducer:
             headers=headers,
             timestamp_ms=timestamp_ms,
         )
+
+    async def __aenter__(self) -> Self:
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exception_type: object,
+        exception: object,
+        traceback: object,
+    ) -> None:
+        await self.stop()

--- a/tests/test_aiokafka/test_aiokafka_producer.py
+++ b/tests/test_aiokafka/test_aiokafka_producer.py
@@ -94,3 +94,17 @@ class TestFakeProducer(IsolatedAsyncioTestCase):
         )[0]
         self.assertEqual(message.key(), "datakey")
         self.assertEqual(message.topic(), "topic_test")
+
+    async def test_context_manager(self) -> None:
+        await self._create_mock_topic()
+
+        async with self.producer as producer:
+            self.assertEqual(self.producer, producer)
+            await self.producer.send_and_wait("topic_test", "skdfjh", key="datakey")
+
+        message: Message = self.kafka.get_messages_in_partition(
+            topic="topic_test",
+            partition=0,
+        )[0]
+        self.assertEqual(message.key(), "datakey")
+        self.assertEqual(message.topic(), "topic_test")


### PR DESCRIPTION
This is present in aiokafka, but was missing here.