### PR TITLE
Consistently treat message key & value as bytes

### DIFF
--- a/mockafka/aiokafka/aiokafka_consumer.py
+++ b/mockafka/aiokafka/aiokafka_consumer.py
@@ -34,11 +34,8 @@ def message_to_record(message: Message, offset: int) -> ConsumerRecord[bytes, by
         missing = ", ".join(x for x, y in fields if y is None)
         raise ValueError(f"Message is missing key components: {missing}")
 
-    key_str: Optional[str] = message.key()
-    value_str: Optional[str] = message.value()
-
-    key = key_str.encode() if key_str is not None else None
-    value = value_str.encode() if value_str is not None else None
+    key: Optional[bytes] = message.key()
+    value: Optional[bytes] = message.value()
 
     headers = message.headers()
 

--- a/mockafka/message.py
+++ b/mockafka/message.py
@@ -14,8 +14,8 @@ from confluent_kafka import (  # type: ignore[import-untyped]
 class Message:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._headers: Optional[list[tuple[str, Optional[bytes]]]] = kwargs.get("headers", None)
-        self._key: Optional[str] = kwargs.get("key", None)
-        self._value: Optional[str] = kwargs.get("value", None)
+        self._key: Optional[bytes] = kwargs.get("key", None)
+        self._value: Optional[bytes] = kwargs.get("value", None)
         self._topic: Optional[str] = kwargs.get("topic", None)
         self._offset: Optional[int] = kwargs.get("offset", None)
         self._error: Optional[KafkaError] = kwargs.get("error", None)
@@ -40,10 +40,10 @@ class Message:
     def headers(self) -> Optional[list[tuple[str, Optional[bytes]]]]:
         return self._headers
 
-    def key(self, *args, **kwargs):
+    def key(self, *args, **kwargs) -> Optional[bytes]:
         return self._key
 
-    def value(self, *args, **kwargs):
+    def value(self, *args, **kwargs) -> Optional[bytes]:
         return self._value
 
     def timestamp(self, *args, **kwargs) -> tuple[int, int]:

--- a/tests/test_aiokafka/test_aiokafka_consumer.py
+++ b/tests/test_aiokafka/test_aiokafka_consumer.py
@@ -42,10 +42,10 @@ class TestAIOKAFKAFakeConsumer(IsolatedAsyncioTestCase):
 
     async def produce_message(self):
         await self.producer.send(
-            topic=self.test_topic, partition=0, key="test", value="test"
+            topic=self.test_topic, partition=0, key=b"test", value=b"test"
         )
         await self.producer.send(
-            topic=self.test_topic, partition=0, key="test1", value="test1"
+            topic=self.test_topic, partition=0, key=b"test1", value=b"test1"
         )
 
     async def test_consume(self):
@@ -118,7 +118,7 @@ class TestAIOKAFKAFakeConsumer(IsolatedAsyncioTestCase):
         self.create_topic()
         await self.produce_message()
         await self.producer.send(
-            topic=self.test_topic, partition=2, key="test2", value="test2"
+            topic=self.test_topic, partition=2, key=b"test2", value=b"test2"
         )
         self.consumer.subscribe(topics=[self.test_topic])
         await self.consumer.start()
@@ -147,7 +147,7 @@ class TestAIOKAFKAFakeConsumer(IsolatedAsyncioTestCase):
         self.create_topic()
         await self.produce_message()
         await self.producer.send(
-            topic=self.test_topic, partition=0, key="test2", value="test2"
+            topic=self.test_topic, partition=0, key=b"test2", value=b"test2"
         )
         self.consumer.subscribe(topics=[self.test_topic])
         await self.consumer.start()
@@ -184,7 +184,7 @@ class TestAIOKAFKAFakeConsumer(IsolatedAsyncioTestCase):
         self.create_topic()
         await self.produce_message()
         await self.producer.send(
-            topic=self.test_topic, partition=1, key="test2", value="test2"
+            topic=self.test_topic, partition=1, key=b"test2", value=b"test2"
         )
         self.consumer.subscribe(topics=[self.test_topic])
         await self.consumer.start()
@@ -212,7 +212,7 @@ class TestAIOKAFKAFakeConsumer(IsolatedAsyncioTestCase):
         self.create_topic()
         await self.produce_message()
         await self.producer.send(
-            topic=self.test_topic, partition=2, key="test2", value="test2"
+            topic=self.test_topic, partition=2, key=b"test2", value=b"test2"
         )
         self.consumer.subscribe(topics=[self.test_topic])
         await self.consumer.start()

--- a/tests/test_aiokafka/test_aiokafka_producer.py
+++ b/tests/test_aiokafka/test_aiokafka_producer.py
@@ -19,8 +19,8 @@ class TestFakeProducer(IsolatedAsyncioTestCase):
         self.admin_client = FakeAIOKafkaAdmin()
 
         self.topic = "test1"
-        self.key = "test_key"
-        self.value = "test_value"
+        self.key = b"test_key"
+        self.value = b"test_value"
 
     async def _create_mock_topic(self):
         await self.admin_client.create_topics(
@@ -96,14 +96,14 @@ class TestFakeProducer(IsolatedAsyncioTestCase):
 
         await self.producer.start()
         try:
-            await self.producer.send_and_wait("topic_test", "sdfjhasdfhjsa", key="datakey")
+            await self.producer.send_and_wait("topic_test", b"sdfjhasdfhjsa", key=b"datakey")
         finally:
             await self.producer.stop()
 
         message: Message = self.kafka.get_messages_in_partition(
             topic="topic_test", partition=0
         )[0]
-        self.assertEqual(message.key(), "datakey")
+        self.assertEqual(message.key(), b"datakey")
         self.assertEqual(message.topic(), "topic_test")
 
     async def test_context_manager(self) -> None:
@@ -111,11 +111,11 @@ class TestFakeProducer(IsolatedAsyncioTestCase):
 
         async with self.producer as producer:
             self.assertEqual(self.producer, producer)
-            await self.producer.send_and_wait("topic_test", "skdfjh", key="datakey")
+            await self.producer.send_and_wait("topic_test", b"skdfjh", key=b"datakey")
 
         message: Message = self.kafka.get_messages_in_partition(
             topic="topic_test",
             partition=0,
         )[0]
-        self.assertEqual(message.key(), "datakey")
+        self.assertEqual(message.key(), b"datakey")
         self.assertEqual(message.topic(), "topic_test")

--- a/tests/test_aiokafka/test_async_decorators.py
+++ b/tests/test_aiokafka/test_async_decorators.py
@@ -44,7 +44,7 @@ class TestDecorators(IsolatedAsyncioTestCase):
             [NewTopic(name="test", num_partitions=16, replication_factor=1)]
         )
 
-    @aproduce(topic="test", key="test_key", value="test_value", partition=4)
+    @aproduce(topic="test", key=b"test_key", value=b"test_value", partition=4)
     async def test_produce_decorator(self):
         await self.consumer.start()
 
@@ -61,8 +61,8 @@ class TestDecorators(IsolatedAsyncioTestCase):
         # check there is no message in mock kafka
         self.assertIsNone(await self.consumer.getone())
 
-    @aproduce(topic="test", key="test_key", value="test_value", partition=4)
-    @aproduce(topic="test", key="test_key1", value="test_value1", partition=0)
+    @aproduce(topic="test", key=b"test_key", value=b"test_value", partition=4)
+    @aproduce(topic="test", key=b"test_key1", value=b"test_value1", partition=0)
     async def test_produce_twice(self):
         await self.consumer.start()
         # subscribe to topic and get message
@@ -91,7 +91,7 @@ class TestDecorators(IsolatedAsyncioTestCase):
         self.assertIsNone(await self.consumer.getone())
 
     @asetup_kafka(topics=[{"topic": "test_topic", "partition": 16}])
-    @aproduce(topic="test_topic", partition=5, key="test_", value="test_value1")
+    @aproduce(topic="test_topic", partition=5, key=b"test_", value=b"test_value1")
     async def test_produce_with_kafka_setup_decorator(self):
         await self.consumer.start()
         # subscribe to topic and get message
@@ -102,8 +102,8 @@ class TestDecorators(IsolatedAsyncioTestCase):
         self.assertEqual(message.key, b"test_")
 
     @asetup_kafka(topics=[{"topic": "test_topic", "partition": 16}])
-    @aproduce(topic="test_topic", partition=5, key="test_", value="test_value1")
-    @aproduce(topic="test_topic", partition=5, key="test_", value="test_value1")
+    @aproduce(topic="test_topic", partition=5, key=b"test_", value=b"test_value1")
+    @aproduce(topic="test_topic", partition=5, key=b"test_", value=b"test_value1")
     @aconsume(topics=["test_topic"])
     async def test_consumer_decorator(self, message: Message | None = None):
         if message is None:

--- a/tests/test_async_mockafka.py
+++ b/tests/test_async_mockafka.py
@@ -38,8 +38,8 @@ async def test_produce_and_consume():
     await producer.start()
     await producer.send(
         headers={},
-        key="test_key",
-        value="test_value",
+        key=b"test_key",
+        value=b"test_value",
         topic="test_topic",
         partition=0,
     )
@@ -60,7 +60,7 @@ async def test_produce_and_consume():
 
 @pytest.mark.asyncio
 @asetup_kafka(topics=[{"topic": "test_topic", "partition": 16}], clean=True)
-@aproduce(topic="test_topic", value="test_value", key="test_key", partition=0)
+@aproduce(topic="test_topic", value=b"test_value", key=b"test_key", partition=0)
 async def test_produce_with_decorator():
     consumer = FakeAIOKafkaConsumer()
     await consumer.start()
@@ -73,7 +73,7 @@ async def test_produce_with_decorator():
 
 @pytest.mark.asyncio
 @asetup_kafka(topics=[{"topic": "test_topic", "partition": 16}], clean=True)
-@aproduce(topic="test_topic", value="test_value", key="test_key", partition=0)
+@aproduce(topic="test_topic", value=b"test_value", key=b"test_key", partition=0)
 @aconsume(topics=["test_topic"])
 async def test_produce_and_consume_with_decorator(message=None):
     if not message:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -74,9 +74,9 @@ class TestFakeConsumer(TestCase):
         self.consumer.subscribe(topics=[self.test_topic])
 
         message = self.consumer.poll()
-        self.assertEqual(message.value(payload=None), "test")
+        self.assertEqual(message.value(payload=None), b"test")
         message = self.consumer.poll()
-        self.assertEqual(message.value(payload=None), "test1")
+        self.assertEqual(message.value(payload=None), b"test1")
 
         self.assertIsNone(self.consumer.poll())
         self.assertIsNone(self.consumer.poll())
@@ -88,11 +88,11 @@ class TestFakeConsumer(TestCase):
 
         message = self.consumer.poll()
         self.consumer.commit()
-        self.assertEqual(message.value(payload=None), "test")
+        self.assertEqual(message.value(payload=None), b"test")
 
         message = self.consumer.poll()
         self.consumer.commit()
-        self.assertEqual(message.value(payload=None), "test1")
+        self.assertEqual(message.value(payload=None), b"test1")
 
         self.assertIsNone(self.consumer.poll())
         self.assertIsNone(self.consumer.poll())

--- a/tests/test_consumer_consistency.py
+++ b/tests/test_consumer_consistency.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import uuid
 from random import randint, choice
 from typing import Any
@@ -26,7 +27,7 @@ class MockConsumer:
         while cnt <= msg_cnt:
             message = self._consumer.poll(timeout=1.0)
             if message is not None:
-                messages.append(message.value())
+                messages.append(json.loads(message.value().decode()))
                 cnt = cnt + 1
 
             self._consumer.commit(message)
@@ -50,7 +51,7 @@ class MockProducer:
     def produce(self, topic: str, key: str, message: dict):
         self._producer.produce(
             key=key + str(uuid.uuid4()),
-            value=message,
+            value=json.dumps(message).encode(),
             topic=topic,
             partition=randint(0, 1),
         )

--- a/tests/test_docrators.py
+++ b/tests/test_docrators.py
@@ -37,8 +37,8 @@ class TestDecorators(TestCase):
         self.consumer.subscribe(topics=["test"])
         message = self.consumer.poll()
 
-        self.assertEqual(message.value(payload=None), "test_value")
-        self.assertEqual(message.key(), "test_key")
+        self.assertEqual(message.value(payload=None), b"test_value")
+        self.assertEqual(message.key(), b"test_key")
 
         # commit message and check
         self.consumer.commit()
@@ -62,8 +62,8 @@ class TestDecorators(TestCase):
         ]
         self.assertCountEqual(
             [
-                ("test_key", "test_value"),
-                ("test_key1", "test_value1"),
+                (b"test_key", b"test_value"),
+                (b"test_key1", b"test_value1"),
             ],
             messages,
         )
@@ -80,12 +80,12 @@ class TestDecorators(TestCase):
         self.consumer.subscribe(topics=["test"])
 
         message = self.consumer.poll()
-        self.assertEqual(message.value(payload=None), "test_value")
-        self.assertEqual(message.key(), "test_key")
+        self.assertEqual(message.value(payload=None), b"test_value")
+        self.assertEqual(message.key(), b"test_key")
 
         message = self.consumer.poll()
-        self.assertEqual(message.value(payload=None), "test_value1")
-        self.assertEqual(message.key(), "test_key1")
+        self.assertEqual(message.value(payload=None), b"test_value1")
+        self.assertEqual(message.key(), b"test_key1")
 
         # commit message and check
         self.consumer.commit()
@@ -100,8 +100,8 @@ class TestDecorators(TestCase):
         self.consumer.subscribe(topics=["test_topic"])
 
         message = self.consumer.poll()
-        self.assertEqual(message.value(payload=None), "test_value1")
-        self.assertEqual(message.key(), "test_")
+        self.assertEqual(message.value(payload=None), b"test_value1")
+        self.assertEqual(message.key(), b"test_")
 
     @setup_kafka(topics=[{"topic": "test_topic", "partition": 16}])
     @produce(topic="test_topic", partition=5, key="test_", value="test_value1")
@@ -111,5 +111,5 @@ class TestDecorators(TestCase):
         if message is None:
             return
 
-        self.assertEqual(message.key(), "test_")
+        self.assertEqual(message.key(), b"test_")
         self.assertEqual(message._partition, 5)

--- a/tests/test_kafka_store.py
+++ b/tests/test_kafka_store.py
@@ -12,8 +12,8 @@ class TestKafkaStore(TestCase):
     DEFAULT_PARTITION = 16
     DEFAULT_MESSAGE = Message(
         headers=None,
-        key="test_key",
-        value='{"test_value": "ok"}',
+        key=b"test_key",
+        value=b'{"test_value": "ok"}',
         topic=TEST_TOPIC,
         offset=None,
         error=None,

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -72,8 +72,8 @@ class TestFakeProducer(TestCase):
         message: Message = self.kafka.get_messages_in_partition(
             topic=self.topic, partition=0
         )[0]
-        self.assertEqual(message.key(), self.key)
-        self.assertEqual(message.value(payload=None), self.value)
+        self.assertEqual(message.key(), self.key.encode())
+        self.assertEqual(message.value(payload=None), self.value.encode())
         self.assertEqual(message.topic(), self.topic)
         self.assertEqual(
             message.headers(),


### PR DESCRIPTION
In real Kafka these are handled as bytes, with libraries providing various mechanisms for serialisation. Previously mockafka had unclear semantics which largely ignored the actual type of the key & value, though mostly assumed they were strings. In turn that lead to confusion when trying to match aiokafka, which only handles them as bytes.

Along with 00ddf18a005426437e8d98d86a7d95770f64f990 this fixes https://github.com/alm0ra/mockafka-py/issues/149.