### PR TITLE
Fix test failures due to bytes/str mismatch in assertions

### DIFF
--- a/tests/test_docrators.py
+++ b/tests/test_docrators.py
@@ -132,8 +132,8 @@ class TestDecorators(TestCase):
             return
 
         # Verify the message was consumed correctly
-        self.assertEqual(message.key(), "fix_key")
-        self.assertEqual(message.value(payload=None), "fix_value")
+        self.assertEqual(message.key(), b"fix_key")
+        self.assertEqual(message.value(payload=None), b"fix_value")
         self.assertEqual(message.partition(), 3)
 
     @setup_kafka(topics=[{"topic": "pytest_fix_test2", "partition": 16}])
@@ -149,8 +149,8 @@ class TestDecorators(TestCase):
             return
 
         # Verify the message was consumed correctly
-        self.assertEqual(message.key(), "fix_key2")
-        self.assertEqual(message.value(payload=None), "fix_value2")
+        self.assertEqual(message.key(), b"fix_key2")
+        self.assertEqual(message.value(payload=None), b"fix_value2")
         self.assertEqual(message.partition(), 7)
 
     @setup_kafka(topics=[{"topic": "multiple_messages_test", "partition": 16}])
@@ -168,8 +168,8 @@ class TestDecorators(TestCase):
             return
 
         # Verify we receive one of the expected messages
-        expected_keys = ["msg1_key", "msg2_key", "msg3_key"]
-        expected_values = ["msg1_value", "msg2_value", "msg3_value"]
+        expected_keys = [b"msg1_key", b"msg2_key", b"msg3_key"]
+        expected_values = [b"msg1_value", b"msg2_value", b"msg3_value"]
         expected_partitions = [1, 2, 3]
 
         self.assertIn(message.key(), expected_keys)
@@ -188,8 +188,8 @@ class TestDecorators(TestCase):
         if message is None:
             return
 
-        self.assertEqual(message.key(), "edge_key")
-        self.assertEqual(message.value(payload=None), "edge_value")
+        self.assertEqual(message.key(), b"edge_key")
+        self.assertEqual(message.value(payload=None), b"edge_value")
         self.assertEqual(message.partition(), 0)
 
     @setup_kafka(topics=[{"topic": "signature_test", "partition": 16}])
@@ -204,8 +204,8 @@ class TestDecorators(TestCase):
         if message is None:
             return
 
-        self.assertEqual(message.key(), "sig_key")
-        self.assertEqual(message.value(payload=None), "sig_value")
+        self.assertEqual(message.key(), b"sig_key")
+        self.assertEqual(message.value(payload=None), b"sig_value")
         self.assertEqual(message.partition(), 5)
 
     def test_signature_modification_verification(self):

--- a/tests/test_pytest_fixture_issue.py
+++ b/tests/test_pytest_fixture_issue.py
@@ -45,8 +45,8 @@ class TestPytestFixtureIssueFix(TestCase):
                 return
 
             # Verify the message content
-            self.assertEqual(message.key(), 'test_key')
-            self.assertEqual(message.value(payload=None), 'test_value')
+            self.assertEqual(message.key(), b'test_key')
+            self.assertEqual(message.value(payload=None), b'test_value')
             self.assertEqual(message.partition(), 4)
 
         # This should not raise any pytest fixture errors
@@ -146,8 +146,8 @@ class TestPytestFixtureIssueFix(TestCase):
             if message is None:
                 return
             
-            self.assertEqual(message.key(), "compat_key")
-            self.assertEqual(message.value(payload=None), "compat_value")
+            self.assertEqual(message.key(), b"compat_key")
+            self.assertEqual(message.value(payload=None), b"compat_value")
             self.assertEqual(message.partition(), 1)
         
         # This should work without any issues
@@ -185,8 +185,8 @@ class TestPytestFixtureIssueFix(TestCase):
             
             # Should receive one of the two messages
             expected_data = [
-                ("key1", "value1", 1),
-                ("key2", "value2", 2)
+                (b"key1", b"value1", 1),
+                (b"key2", b"value2", 2)
             ]
             
             actual_data = (message.key(), message.value(payload=None), message.partition())


### PR DESCRIPTION
These tests were added in 4a6820b8c95bc1c9db63665609662b2d5a05a2ec (https://github.com/alm0ra/mockafka-py/pull/203) and conflicted with the bytes fix added in 415fcda204c6fe8a5c9efcfa6f3454d15de02e1a (https://github.com/alm0ra/mockafka-py/pull/204) merged shortly before it.