### PR TITLE
Add typing to the easier two async decorators

### DIFF
--- a/mockafka/aiokafka/aiokafka_producer.py
+++ b/mockafka/aiokafka/aiokafka_producer.py
@@ -73,11 +73,11 @@ class FakeAIOKafkaProducer:
 
     async def send(
         self,
-        topic,
+        topic: str,
         value: Optional[bytes] = None,
         key: Optional[bytes] = None,
-        partition=0,
-        timestamp_ms=None,
+        partition: int = 0,
+        timestamp_ms: Optional[int] = None,
         headers: Optional[list[tuple[str, Optional[bytes]]]] = None,
     ) -> asyncio.Future[None]:
         await self._produce(
@@ -94,11 +94,11 @@ class FakeAIOKafkaProducer:
 
     async def send_and_wait(
         self,
-        topic,
+        topic: str,
         value: Optional[bytes] = None,
         key: Optional[bytes] = None,
-        partition=0,
-        timestamp_ms=None,
+        partition: int = 0,
+        timestamp_ms: Optional[int] = None,
         headers=None,
     ) -> None:
         future = await self.send(

--- a/mockafka/decorators/asetup_kafka.py
+++ b/mockafka/decorators/asetup_kafka.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
 from functools import wraps
+from typing import Awaitable, Callable, TypeVar
 
 from aiokafka.admin import NewTopic  # type: ignore[import-untyped]
+from typing_extensions import ParamSpec
 
 from mockafka.aiokafka import FakeAIOKafkaAdmin
 from mockafka.decorators.typing import TopicConfig
 
+P = ParamSpec('P')
+R = TypeVar('R')
 
-def asetup_kafka(topics: list[TopicConfig], clean: bool = False):
+
+def asetup_kafka(
+    topics: list[TopicConfig],
+    clean: bool = False,
+) -> Callable[
+    [Callable[P, Awaitable[R]]],
+    Callable[P, Awaitable[R]],
+]:
     """
     asetup_kafka is a decorator for setting up mock Kafka topics using a FakeAIOKafkaAdminClient.
 
@@ -32,9 +43,9 @@ def asetup_kafka(topics: list[TopicConfig], clean: bool = False):
 
     """
 
-    def decorator(func):
+    def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
         @wraps(func)
-        async def wrapper(*args, **kwargs):
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             # Create a FakeAdminClient instance with the specified clean option
             fake_admin = FakeAIOKafkaAdmin(clean=clean)
 


### PR DESCRIPTION
These don't modify the signature of the test function being decorated, so are much easier to annotated. `aconsume` is somewhat harder and may need signature-modifying functionality which isn't stable yet.