### PR TITLE
Support aiokafka 0.12

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1480,4 +1480,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<4.0"
-content-hash = "1e68b53ef462ad3452fa561c2177940e43231d4c00bdc1deaaa95a5992443026"
+content-hash = "8b655a42c727f8ce86d6a65bfd771d61cea77ef6288e7b2b712bb2a1c1cf893a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 confluent-kafka = ">= 1.9.2"
-aiokafka = ">=0.10,<0.12"
+aiokafka = ">=0.10,<0.13"
 typing-extensions = "^4.12.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
According to their [release notes](https://github.com/aio-libs/aiokafka/releases/tag/v0.12.0), there's nothing breaking here.

Fixes https://github.com/alm0ra/mockafka-py/issues/228