### PR TITLE
Update allowed aiokafka versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1480,4 +1480,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<4.0"
-content-hash = "a549f67c1331b3e1598e419ea66d8f46f6639a5dc092574758fc5e02785693da"
+content-hash = "270745373028689e79d50fe93958d2fd079a3e596947bcf1b24bc4db8c28936c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 confluent-kafka = ">= 1.9.2"
-aiokafka = ">=0.10,<0.13"
+aiokafka = ">=0.10,<0.14"
 typing-extensions = "^4.12.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
From reading the changelog, there doesn't appear to be anything we need to do in order to support this new version.

https://github.com/aio-libs/aiokafka/blob/master/CHANGES.rst#0130-2026-01-02